### PR TITLE
Remove babel

### DIFF
--- a/lib/sender.js
+++ b/lib/sender.js
@@ -7,15 +7,12 @@ const Pathfinder = require('five-bells-pathfind').Pathfinder
 function Sender (params) {
   this.source_ledger = params.source_ledger
   this.source_username = params.source_username
+  this.source_account = params.source_account || toAccount(this.source_ledger, this.source_username)
   this.source_password = params.source_password
   this.destination_ledger = params.destination_ledger
-  this.destination_username = params.destination_username
+  this.destination_account = params.destination_account || toAccount(this.destination_ledger, this.destination_username)
   this.destination_amount = params.destination_amount
-
-  this.source_account = toAccount(
-    this.source_ledger, this.source_username)
-  this.destination_account = toAccount(
-    this.destination_ledger, this.destination_username)
+  this.destination_memo = params.destination_memo
 
   this.pathfinder = new Pathfinder({
     crawler: {
@@ -67,6 +64,9 @@ Sender.prototype.setupTransfers = function * () {
   let expiryDate = new Date(Date.now() + (finalTransfer.expiry_duration * 1000))
   finalTransfer.expires_at = expiryDate.toISOString()
   delete finalTransfer.expiry_duration
+  if (this.destination_memo) {
+    finalTransfer.credits[0].memo = this.destination_memo
+  }
 
   let executionCondition = yield this.getCondition()
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/interledger/five-bells-sender#readme",
   "dependencies": {
     "co": "^4.6.0",
-    "five-bells-pathfind": "~4.0.1",
+    "five-bells-pathfind": "4.0.1",
     "superagent": "^1.5.0",
     "uuid4": "^1.0.0"
   },


### PR DESCRIPTION
Babel is creating more headache than it's worth right now. Revert to the version without babel and without async/await
Also add `destination_memo` and `destination_account` params