### PR TITLE
Corresponding change to Notary API 2.0.0

### DIFF
--- a/src/sender.js
+++ b/src/sender.js
@@ -129,7 +129,7 @@ Sender.prototype.setupCase = async function () {
       execution_condition: this.receipt_condition,
       expires_at: this.getExpiresAt(this.subpayments[0].source_transfers[0]),
       notaries: [{url: this.notary}],
-      transfers: this.transfers.map(transfer => transfer.id)
+      notification_targets: this.transfers.map(transfer => transfer.id + '/fulfillment')
     })
   if (caseRes.statusCode >= 400) {
     throw new Error('Notary error: ' + caseRes.statusCode + ' ' +


### PR DESCRIPTION
Notary's API changed as of 1/21/2016: https://docs.google.com/document/d/1Ise6r47VoUPmuoDuLWervwRRJuFu36rkHGUvX_iFLYE/edit?ts=5669bf4d

This PR changes what five-bells-sender to Notary according to the new API. 

