### PR TITLE
Use Node ES6 instead of Babel

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,4 +1,3 @@
 {
-  "extends": "standard",
-  "parser": "babel-eslint"
+  "extends": "standard"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 /node_modules/
-dist
+babel
 *.log

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,2 @@
 .npmrc
-src/
+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 You can see the visualization in action as part of the [`five-bells-demo`](https://github.com/interledger/five-bells-demo)!
 
-# Example: Universal Mode
+## Example: Universal Mode
 
 ``` js
     send({
@@ -26,7 +26,7 @@ You can see the visualization in action as part of the [`five-bells-demo`](https
     })
 ```
 
-# Example: Atomic Mode
+## Example: Atomic Mode
 
 ``` js
     send({
@@ -44,3 +44,6 @@ You can see the visualization in action as part of the [`five-bells-demo`](https
     })
 ```
 
+## Browser Support
+
+This library can be compiled with [Babel](https://babeljs.io/) using the command `npm run build`. The compiled files will be in the `babel/` folder.

--- a/package.json
+++ b/package.json
@@ -7,12 +7,11 @@
     "five-bells",
     "ilp"
   ],
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "scripts": {
     "lint": "eslint src test",
-    "test": "babel-node ./node_modules/.bin/_mocha test/*.test.js",
-    "build": "babel src --out-dir dist",
-    "prepublish": "npm run build"
+    "test": "_mocha test/*.test.js",
+    "build": "babel src --out-dir babel"
   },
   "repository": {
     "type": "git",
@@ -25,14 +24,15 @@
   },
   "homepage": "https://github.com/interledger/five-bells-sender#readme",
   "dependencies": {
-    "babel-runtime": "^6.3.19",
     "canonical-json": "0.0.4",
+    "co": "^4.6.0",
     "five-bells-pathfind": "~4.2.0",
     "five-bells-shared": "~8.10.0",
     "superagent": "^1.5.0",
     "uuid4": "^1.0.0"
   },
   "devDependencies": {
+    "co-mocha": "^1.1.2",
     "babel": "^6.3.13",
     "babel-cli": "^6.3.17",
     "babel-core": "^6.3.17",
@@ -40,6 +40,7 @@
     "babel-plugin-transform-runtime": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
     "babel-preset-stage-0": "^6.3.13",
+    "babel-runtime": "^6.3.19",
     "eslint": "^1.3.1",
     "eslint-config-standard": "^4.3.1",
     "eslint-plugin-standard": "^1.3.0",

--- a/src/notaryUtils.js
+++ b/src/notaryUtils.js
@@ -1,9 +1,10 @@
 'use strict'
 
+const co = require('co')
 const request = require('superagent')
 const uuid = require('uuid4')
-import {getTransferState} from './transferUtils'
-import * as Payments from './payments'
+const getTransferState = require('./transferUtils').getTransferState
+const Payments = require('./payments')
 
 /**
  * @param {Object} params
@@ -13,23 +14,25 @@ import * as Payments from './payments'
  * @param {String} params.expiresAt
  * @returns {Promise<URI>} Case ID
  */
-export async function setupCase (params) {
-  const caseID = params.notary + '/cases/' + uuid()
-  const caseRes = await request
-    .put(caseID)
-    .send({
-      id: caseID,
-      state: 'proposed',
-      execution_condition: params.receiptCondition,
-      expires_at: params.expiresAt,
-      notaries: [{url: params.notary}],
-      notification_targets: Payments.toTransfers(params.payments).map(transferToFulfillmentURI)
-    })
-  if (caseRes.status >= 400) {
-    throw new Error('Notary error: ' + caseRes.status + ' ' +
-      JSON.stringify(caseRes.body))
-  }
-  return caseID
+function setupCase (params) {
+  return co(function * () {
+    const caseID = params.notary + '/cases/' + uuid()
+    const caseRes = yield request
+      .put(caseID)
+      .send({
+        id: caseID,
+        state: 'proposed',
+        execution_condition: params.receiptCondition,
+        expires_at: params.expiresAt,
+        notaries: [{url: params.notary}],
+        notification_targets: Payments.toTransfers(params.payments).map(transferToFulfillmentURI)
+      })
+    if (caseRes.status >= 400) {
+      throw new Error('Notary error: ' + caseRes.status + ' ' +
+        JSON.stringify(caseRes.body))
+    }
+    return caseID
+  })
 }
 
 /**
@@ -45,13 +48,18 @@ function transferToFulfillmentURI (transfer) {
  * @param {URI} caseID
  * @param {Promise}
  */
-export async function postFulfillmentToNotary (finalTransfer, caseID) {
-  const finalTransferState = await getTransferState(finalTransfer)
-  const notaryFulfillmentRes = await request
-    .put(caseID + '/fulfillment')
-    .send({ type: finalTransferState.type, signature: finalTransferState.signature })
-  if (notaryFulfillmentRes >= 400) {
-    throw new Error('Remote error: ' + notaryFulfillmentRes.status + ' ' +
-      JSON.stringify(notaryFulfillmentRes.body))
-  }
+function postFulfillmentToNotary (finalTransfer, caseID) {
+  return co(function * () {
+    const finalTransferState = yield getTransferState(finalTransfer)
+    const notaryFulfillmentRes = yield request
+      .put(caseID + '/fulfillment')
+      .send({ type: finalTransferState.type, signature: finalTransferState.signature })
+    if (notaryFulfillmentRes >= 400) {
+      throw new Error('Remote error: ' + notaryFulfillmentRes.status + ' ' +
+        JSON.stringify(notaryFulfillmentRes.body))
+    }
+  })
 }
+
+exports.setupCase = setupCase
+exports.postFulfillmentToNotary = postFulfillmentToNotary

--- a/test/conditionUtils.test.js
+++ b/test/conditionUtils.test.js
@@ -2,11 +2,7 @@
 'use strict'
 const assert = require('assert')
 const nock = require('nock')
-import {
-  getReceiptCondition,
-  getExecutionCondition,
-  getCancellationCondition
-} from '../src/conditionUtils'
+const conditionUtils = require('../src/conditionUtils')
 
 const notary = 'http://notary.example'
 const transfer = {
@@ -15,12 +11,12 @@ const transfer = {
 }
 
 describe('conditionUtils.getReceiptCondition', function () {
-  it('builds a Condition', async function () {
+  it('builds a Condition', function * () {
     const transferNock = nock(transfer.id).get('/state').reply(200, {
       type: 'ed25519-sha512',
       public_key: 1234
     })
-    assert.deepEqual((await getReceiptCondition(transfer, 'executed')),
+    assert.deepEqual((yield conditionUtils.getReceiptCondition(transfer, 'executed')),
       {
         message_hash: 'ZZeLK/FVt4iGMxy6FDohwnFxNBbPbC/2Hf7Y2a9/WLBb/AlmLTpA91lVRmMJLSSLwTgOUsqGTi9EPzlowHdl9Q==',
         signer: 'http://ledger.example',
@@ -36,9 +32,9 @@ describe('conditionUtils.getExecutionCondition', function () {
     it('returns an "and" Condition', function () {
       const receiptCondition = [1]
       assert.deepEqual(
-        getExecutionCondition({
-          notary,
-          receiptCondition,
+        conditionUtils.getExecutionCondition({
+          notary: notary,
+          receiptCondition: receiptCondition,
           caseID: 1234,
           notaryPublicKey: 5678
         }),
@@ -61,7 +57,7 @@ describe('conditionUtils.getExecutionCondition', function () {
     it('returns the receiptCondition', function () {
       const receiptCondition = [1]
       assert.deepEqual(
-        getExecutionCondition({receiptCondition}),
+        conditionUtils.getExecutionCondition({receiptCondition}),
         receiptCondition)
     })
   })
@@ -70,10 +66,10 @@ describe('conditionUtils.getExecutionCondition', function () {
 describe('conditionUtils.getCancellationCondition', function () {
   it('returns an ed25519-sha512 Condition', function () {
     assert.deepEqual(
-      getCancellationCondition({
+      conditionUtils.getCancellationCondition({
         caseID: 1234,
         notaryPublicKey: 5678,
-        notary
+        notary: notary
       }),
       {
         type: 'ed25519-sha512',

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+-r co-mocha

--- a/test/transferUtils.test.js
+++ b/test/transferUtils.test.js
@@ -1,14 +1,9 @@
 /* eslint-env node, mocha */
 'use strict'
+
 const assert = require('assert')
 const nock = require('nock')
-import {
-  setupTransferConditionsAtomic,
-  setupTransferConditionsUniversal,
-  postTransfer,
-  transferExpiresAt,
-  getTransferState
-} from '../src/transferUtils'
+const transferUtils = require('../src/transferUtils')
 
 const transfer = { id: 'http://ledger.example/transfers/1234' }
 const now = 1454400000000
@@ -18,7 +13,7 @@ describe('transferUtils.setupTransferConditionsAtomic', function () {
     const executionCondition = [1]
     const cancellationCondition = [2]
     assert.deepEqual(
-      setupTransferConditionsAtomic({
+      transferUtils.setupTransferConditionsAtomic({
         id: transfer.id,
         expiry_duration: 1
       }, {caseID: 123, executionCondition, cancellationCondition}),
@@ -35,7 +30,7 @@ describe('transferUtils.setupTransferConditionsUniversal', function () {
   it('adds the execution_condition when isFinalTransfer=false', function () {
     const executionCondition = [1]
     assert.deepEqual(
-      setupTransferConditionsUniversal({
+      transferUtils.setupTransferConditionsUniversal({
         id: transfer.id,
         expiry_duration: 1
       }, {isFinalTransfer: false, now, executionCondition}),
@@ -49,7 +44,7 @@ describe('transferUtils.setupTransferConditionsUniversal', function () {
   it('doesn\'t add the execution_condition when isFinalTransfer=true', function () {
     const executionCondition = {}
     assert.deepEqual(
-      setupTransferConditionsUniversal({
+      transferUtils.setupTransferConditionsUniversal({
         id: transfer.id,
         expiry_duration: 1
       }, {isFinalTransfer: true, now, executionCondition}),
@@ -61,20 +56,20 @@ describe('transferUtils.setupTransferConditionsUniversal', function () {
 })
 
 describe('transferUtils.postTransfer', function () {
-  it('returns the state on 200', async function () {
+  it('returns the state on 200', function * () {
     const transferNock = nock(transfer.id)
       .put('')
       .basicAuth({user: 'foo', pass: 'bar'})
       .reply(200, {state: 'prepared'})
-    const state = await postTransfer(transfer, {username: 'foo', password: 'bar'})
+    const state = yield transferUtils.postTransfer(transfer, {username: 'foo', password: 'bar'})
     assert.equal(state, 'prepared')
     transferNock.done()
   })
 
-  it('throws on 400', async function () {
+  it('throws on 400', function * () {
     const transferNock = nock(transfer.id).put('').reply(400)
     try {
-      await postTransfer(transfer, {username: 'foo', password: 'bar'})
+      yield transferUtils.postTransfer(transfer, {username: 'foo', password: 'bar'})
     } catch (err) {
       assert.equal(err.status, 400)
       transferNock.done()
@@ -87,23 +82,23 @@ describe('transferUtils.postTransfer', function () {
 describe('transferUtils.transferExpiresAt', function () {
   it('should return an ISO string', function () {
     assert.equal(
-      transferExpiresAt(1454400000000, {expiry_duration: 2}),
+      transferUtils.transferExpiresAt(1454400000000, {expiry_duration: 2}),
       '2016-02-02T08:00:02.000Z')
   })
 })
 
 describe('transferUtils.getTransferState', function () {
-  it('returns the response body on 200', async function () {
+  it('returns the response body on 200', function * () {
     const transferNock = nock(transfer.id).get('/state').reply(200, {foo: 'bar'})
-    const body = await getTransferState(transfer)
+    const body = yield transferUtils.getTransferState(transfer)
     assert.deepEqual(body, {foo: 'bar'})
     transferNock.done()
   })
 
-  it('should throw an error on 400', async function () {
+  it('should throw an error on 400', function * () {
     const transferNock = nock(transfer.id).get('/state').reply(400)
     try {
-      await getTransferState(transfer)
+      yield transferUtils.getTransferState(transfer)
     } catch (err) {
       assert.equal(err.status, 400)
       transferNock.done()


### PR DESCRIPTION
Babel compilation is now optional to provide browser support
All ES7 functionality has been removed and replaced with ES6 features supported by Node 4.x
Fixes https://github.com/interledger/five-bells-sender/issues/22