### PR TITLE
[FEATURE] Support payment by source amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,19 @@ You can see the visualization in action as part of the [`five-bells-demo`](https
     })
 ```
 
+## Example: Universal Mode with fixed source amount
+
+``` js
+    send({
+      sourceAccount:      'http://localhost:3001/accounts/alice',
+      sourcePassword:     'alice',
+      destinationAccount: 'http://localhost:3002/accounts/alice',
+      sourceAmount:       '1',
+    }).then(function() {
+      console.log('success')
+    })
+```
+
 ## Example: Atomic Mode
 
 ``` js

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "canonical-json": "0.0.4",
     "co": "^4.6.0",
-    "five-bells-pathfind": "~4.2.0",
+    "five-bells-pathfind": "~4.3.0",
     "five-bells-shared": "~8.10.0",
     "superagent": "^1.5.0",
     "uuid4": "^1.0.0"

--- a/src/payments.js
+++ b/src/payments.js
@@ -10,7 +10,7 @@ const transferUtils = require('./transferUtils')
  * @param {URI} sourceAccount
  * @returns {[Payment]}
  */
-function setupTransfers (payments, sourceAccount) {
+function setupTransfers (payments, sourceAccount, destinationAccount) {
   // The forEach only modifies `source_transfers` because:
   //   payment[n-1].destination_transfers == payment[n].source_transfers
   // The final transfer is updated at the end.
@@ -35,6 +35,7 @@ function setupTransfers (payments, sourceAccount) {
   const finalTransfer = finalPayment.destination_transfers[0]
   finalTransfer.id = finalTransfer.ledger + '/transfers/' + uuid()
   finalTransfer.additional_info = {part_of_payment: finalPayment.id}
+  finalTransfer.credits[0].account = destinationAccount
   return payments
 }
 


### PR DESCRIPTION
This changes the `executePayment` API, which I don't believe anyone is using yet. If you are, just add the `destinationAccount` parameter.

Fixes https://github.com/interledger/five-bells-sender/issues/24