### PR TITLE
Expose condition logic in sender (RILP-304)

### DIFF
--- a/src/conditionUtils.js
+++ b/src/conditionUtils.js
@@ -10,18 +10,30 @@ const getTransferState = require('./transferUtils').getTransferState
  * @param {TransferState} state "prepared" | "executed"
  * @returns {Promise<Condition>}
  */
-function getReceiptCondition (finalTransfer, state) {
+function getTransferReceiptCondition (finalTransfer, state) {
   // Execution condition is the final transfer in the chain
   return getTransferState(finalTransfer)
-    .then(finalTransferState => ({
-      message_hash: hashJSON({
-        id: finalTransfer.id,
-        state: state
-      }),
-      signer: finalTransfer.ledger,
-      public_key: finalTransferState.public_key,
-      type: finalTransferState.type
-    }))
+    .then(finalTransferState => (
+      getReceiptCondition(hashJSON({
+        id: finalTransfer.id, state
+      }), finalTransfer.ledger, finalTransferState.public_key, finalTransferState.type))
+    )
+}
+
+/**
+ * @param {String} messageHash
+ * @param {URI} signer
+ * @param {String} publicKey
+ * @param {String} signingAlgorithm
+ * @returns {Condition}
+ */
+function getReceiptCondition (messageHash, signer, publicKey, signingAlgorithm) {
+  return {
+    message_hash: messageHash,
+    signer,
+    public_key: publicKey,
+    type: signingAlgorithm
+  }
 }
 
 /**
@@ -85,6 +97,7 @@ function sha512 (str) {
   return crypto.createHash('sha512').update(str).digest('base64')
 }
 
+exports.getTransferReceiptCondition = getTransferReceiptCondition
 exports.getReceiptCondition = getReceiptCondition
 exports.getExecutionCondition = getExecutionCondition
 exports.getCancellationCondition = getCancellationCondition

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ function executePayment (_subpayments, params) {
     // that all of the transfers are prepared.
     const receiptConditionState = isAtomic ? 'prepared' : 'executed'
     const receiptCondition = params.receiptCondition ||
-      (yield conditionUtils.getReceiptCondition(
+      (yield conditionUtils.getTransferReceiptCondition(
         Payments.toFinalTransfer(subpayments),
         receiptConditionState))
 
@@ -220,3 +220,10 @@ module.exports = sendPayment
 module.exports.default = sendPayment
 module.exports.executePayment = executePayment
 module.exports.findPath = findPath
+
+/**
+ * Expose condition methods
+ */
+module.exports.getReceiptCondition = conditionUtils.getReceiptCondition
+module.exports.getExecutionCondition = conditionUtils.getExecutionCondition
+module.exports.getCancellationCondition = conditionUtils.getCancellationCondition

--- a/test/conditionUtils.test.js
+++ b/test/conditionUtils.test.js
@@ -10,13 +10,13 @@ const transfer = {
   ledger: 'http://ledger.example'
 }
 
-describe('conditionUtils.getReceiptCondition', function () {
-  it('builds a Condition', function * () {
+describe('conditionUtils.getTransferReceiptCondition', function () {
+  it('builds a Condition from a transfer object', function * () {
     const transferNock = nock(transfer.id).get('/state').reply(200, {
       type: 'ed25519-sha512',
       public_key: 1234
     })
-    assert.deepEqual((yield conditionUtils.getReceiptCondition(transfer, 'executed')),
+    assert.deepEqual((yield conditionUtils.getTransferReceiptCondition(transfer, 'executed')),
       {
         message_hash: 'ZZeLK/FVt4iGMxy6FDohwnFxNBbPbC/2Hf7Y2a9/WLBb/AlmLTpA91lVRmMJLSSLwTgOUsqGTi9EPzlowHdl9Q==',
         signer: 'http://ledger.example',
@@ -24,6 +24,18 @@ describe('conditionUtils.getReceiptCondition', function () {
         public_key: 1234
       })
     transferNock.done()
+  })
+})
+
+describe('conditionUtils.getReceiptCondition', function () {
+  it('builds a Condition', function * () {
+    assert.deepEqual((conditionUtils.getReceiptCondition('ZZeLK/FVt4iGMxy6FDohwnFxNBbPbC/2Hf7Y2a9/WLBb/AlmLTpA91lVRmMJLSSLwTgOUsqGTi9EPzlowHdl9Q==', 'http://ledger.example', 1234, 'ed25519-sha512')),
+      {
+        message_hash: 'ZZeLK/FVt4iGMxy6FDohwnFxNBbPbC/2Hf7Y2a9/WLBb/AlmLTpA91lVRmMJLSSLwTgOUsqGTi9EPzlowHdl9Q==',
+        signer: 'http://ledger.example',
+        type: 'ed25519-sha512',
+        public_key: 1234
+      })
   })
 })
 


### PR DESCRIPTION
We had a request from the RC team to expose the condition logic. See [this](https://ripplelabs.atlassian.net/browse/RILP-304) ticket. From my initial conversations, I got the sense that all the required functionality exists, but the sender API doesn't quite fit RC's use case. @gip @mwshortt let's discuss if we want to expose this API in `index.js` (as implemented), and also determine if any further changes are needed for RC.