### PR TITLE
[FIX] Allow client to specify ID of final transfer

### DIFF
--- a/src/payments.js
+++ b/src/payments.js
@@ -5,6 +5,8 @@ const uuid = require('node-uuid').v4
 /**
  * @param {Payment[]} payments
  * @param {URI} sourceAccount
+ * @param {URI} destinationAccount
+ * @param {Object} additionalInfo
  * @returns {Payment[]}
  */
 function setupTransfers (payments, sourceAccount, destinationAccount, additionalInfo) {
@@ -14,7 +16,7 @@ function setupTransfers (payments, sourceAccount, destinationAccount, additional
   payments.forEach(function (payment, i) {
     validateOneToOnePayment(payment)
     const transfer = payment.source_transfers[0]
-    transfer.id = transfer.ledger + '/transfers/' + uuid()
+    transfer.id = transfer.id || transfer.ledger + '/transfers/' + uuid()
     transfer.additional_info = Object.assign({}, additionalInfo)
     transfer.additional_info.part_of_payment = payment.id
 
@@ -32,7 +34,7 @@ function setupTransfers (payments, sourceAccount, destinationAccount, additional
   // Create final (rightmost) transfer
   const finalPayment = payments[payments.length - 1]
   const finalTransfer = finalPayment.destination_transfers[0]
-  finalTransfer.id = finalTransfer.ledger + '/transfers/' + uuid()
+  finalTransfer.id = finalTransfer.id || finalTransfer.ledger + '/transfers/' + uuid()
   finalTransfer.additional_info = Object.assign({}, additionalInfo)
   finalTransfer.additional_info.part_of_payment = finalPayment.id
   finalTransfer.credits[0].account = destinationAccount

--- a/test/payments.test.js
+++ b/test/payments.test.js
@@ -49,6 +49,14 @@ describe('Payments.setupTransfers', function () {
     assert.equal(payment.destination_transfers[0].credits[0].account, bob)
   })
 
+  it('should use provided transfer ID', function () {
+    const transferID = 'http://eur-ledger.example/transfers/35bc13b3-b929-446d-9ed7-e78d75abef07'
+    const quote = clone(this.quote)
+    quote[0].destination_transfers[0].id = transferID
+    const payment = Payments.setupTransfers(quote, alice, bob)[0]
+    assert(transferID === payment.destination_transfers[0].id)
+  })
+
   it('setups up valid payments', function () {
     const payments = Payments.setupTransfers(this.quotes, alice, bob)
     assert.equal(payments[0].source_transfers[0].debits[0].account, alice)


### PR DESCRIPTION
If the user specifies a custom receipt condition, it will likely involve a hash of the ID of the final transfer. In this case, they will want to pass this transfer ID to the sender, so that the sender can create transfers with the appropriate IDs (currently the sender generates random IDs for all transfers it creates).