### PR TITLE
New crypto-conditions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
   "homepage": "https://github.com/interledger/five-bells-sender#readme",
   "dependencies": {
     "bignumber.js": "^2.3.0",
-    "canonical-json": "0.0.4",
     "co": "^4.6.0",
-    "five-bells-shared": "~12.2.0",
+    "five-bells-condition": "^3.0.1",
+    "five-bells-shared": "~14.0.0",
     "node-uuid": "^1.4.7",
     "superagent": "^1.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "eslint": "^1.3.1",
     "eslint-config-standard": "^4.3.1",
     "eslint-plugin-standard": "^1.3.0",
-    "five-bells-integration-test": "^1.1.4",
+    "five-bells-integration-test": "^2.0.0",
     "mocha": "^2.4.5",
     "nock": "^7.0.2"
   }

--- a/src/notaryUtils.js
+++ b/src/notaryUtils.js
@@ -3,15 +3,11 @@
 const co = require('co')
 const request = require('superagent')
 const uuid = require('node-uuid').v4
-const getTransferState = require('./transferUtils').getTransferState
-
-const STATE_RETRY_ATTEMPTS = 5
-const STATE_RETRY_INTERVAL = 1000
 
 /**
  * @returns {String} New case ID
  */
-function createCaseID () {
+function createCaseId () {
   return uuid()
 }
 
@@ -21,27 +17,27 @@ function createCaseID () {
  * @param {Condition} params.receiptCondition
  * @param {Transfer[]} params.transfers
  * @param {String} params.expiresAt
- * @param {String} params.caseID
+ * @param {String} params.caseId
  * @returns {Promise<URI>} Case ID
  */
 function setupCase (params) {
   return co(function * () {
-    const uniqueID = params.caseID || uuid()
+    const uniqueID = params.caseId || uuid()
     if (uniqueID.length > 40) {
-      throw new Error('caseID length is limited to 40 characters')
+      throw new Error('caseId length is limited to 40 characters')
     }
-    const caseID = params.notary + '/cases/' + uniqueID
+    const caseId = params.notary + '/cases/' + uniqueID
     yield request
-      .put(caseID)
+      .put(caseId)
       .send({
-        id: caseID,
+        id: caseId,
         state: 'proposed',
         execution_condition: params.receiptCondition,
         expires_at: params.expiresAt,
         notaries: [params.notary],
         notification_targets: params.transfers.map(transferToFulfillmentURI)
       })
-    return caseID
+    return caseId
   })
 }
 
@@ -53,45 +49,5 @@ function transferToFulfillmentURI (transfer) {
   return transfer.id + '/fulfillment'
 }
 
-/**
- * @param {Transfer} finalTransfer
- * @param {URI} caseID
- * @param {Promise}
- */
-function postFulfillmentToNotary (finalTransfer, caseID) {
-  return co(function * () {
-    const finalTransferState = yield waitForTransferState(finalTransfer, 'prepared')
-    yield request
-      .put(caseID + '/fulfillment')
-      .send({ type: finalTransferState.type, signature: finalTransferState.signature })
-  })
-}
-
-/**
- * @param {Transfer} transfer
- * @param {TransferState} state
- * @returns {SignedMessageTemplate}
- */
-function * waitForTransferState (transfer, state) {
-  for (let i = 0; i < STATE_RETRY_ATTEMPTS; i++) {
-    const finalTransferState = yield getTransferState(transfer)
-    if (finalTransferState.message.state === state) {
-      return finalTransferState
-    } else {
-      yield wait(STATE_RETRY_INTERVAL)
-    }
-  }
-  throw new Error('Transfer ' + transfer.id + ' still hasn\'t reached state=' + state)
-}
-
-/**
- * @param {Integer} ms
- * @returns {Promise}
- */
-function wait (ms) {
-  return new Promise(function (resolve, reject) { setTimeout(resolve, ms) })
-}
-
 exports.setupCase = setupCase
-exports.postFulfillmentToNotary = postFulfillmentToNotary
-exports.createCaseID = createCaseID
+exports.createCaseId = createCaseId

--- a/test/conditionUtils.test.js
+++ b/test/conditionUtils.test.js
@@ -1,61 +1,28 @@
 /* eslint-env node, mocha */
 'use strict'
 const assert = require('assert')
-const nock = require('nock')
 const conditionUtils = require('../src/conditionUtils')
 
 const notary = 'http://notary.example'
-const transfer = {
-  id: 'http://ledger.example/transfers/1234',
-  ledger: 'http://ledger.example'
-}
-
-describe('conditionUtils.getReceiptCondition', function () {
-  it('builds a Condition', function * () {
-    const transferNock = nock(transfer.id).get('/state').reply(200, {
-      type: 'ed25519-sha512',
-      public_key: 1234
-    })
-    assert.deepEqual((yield conditionUtils.getReceiptCondition(transfer, 'executed')),
-      {
-        message_hash: 'ZZeLK/FVt4iGMxy6FDohwnFxNBbPbC/2Hf7Y2a9/WLBb/AlmLTpA91lVRmMJLSSLwTgOUsqGTi9EPzlowHdl9Q==',
-        signer: 'http://ledger.example',
-        type: 'ed25519-sha512',
-        public_key: 1234
-      })
-    transferNock.done()
-  })
-})
 
 describe('conditionUtils.getExecutionCondition', function () {
   describe('atomic mode', function () {
     it('returns an "and" Condition', function () {
-      const receiptCondition = [1]
-      assert.deepEqual(
+      const receiptCondition = 'cc:0:3:vmvf6B7EpFalN6RGDx9F4f4z0wtOIgsIdCmbgv06ceI:7'
+      assert.equal(
         conditionUtils.getExecutionCondition({
           notary: notary,
           receiptCondition: receiptCondition,
-          caseID: 1234,
-          notaryPublicKey: 5678
+          caseId: 1234,
+          notaryPublicKey: '4QRmhUtrxlwQYaO+c8K2BtCd6c4D8HVmy5fLDSjsH6A='
         }),
-        {
-          type: 'and',
-          subconditions: [
-            {
-              type: 'ed25519-sha512',
-              signer: notary,
-              public_key: 5678,
-              message_hash: 'dm5xWlvQPyH0+bfK80HVCXgViBpEG0JQm2oorRIOQqfQKwC5cDwwdMvyXRSFGxbHJXWdjlkrtZK+3rAkIJMUFw=='
-            },
-            receiptCondition
-          ]
-        })
+        'cc:2:2f:iJDUYZFO49HAOnYWVPNkF6QNrzvF7rWbVoOZjiIOqzc:142')
     })
   })
 
   describe('universal mode', function () {
     it('returns the receiptCondition', function () {
-      const receiptCondition = [1]
+      const receiptCondition = 'cc:0:3:vmvf6B7EpFalN6RGDx9F4f4z0wtOIgsIdCmbgv06ceI:7'
       assert.deepEqual(
         conditionUtils.getExecutionCondition({receiptCondition}),
         receiptCondition)
@@ -67,15 +34,10 @@ describe('conditionUtils.getCancellationCondition', function () {
   it('returns an ed25519-sha512 Condition', function () {
     assert.deepEqual(
       conditionUtils.getCancellationCondition({
-        caseID: 1234,
-        notaryPublicKey: 5678,
+        caseId: 1234,
+        notaryPublicKey: '4QRmhUtrxlwQYaO+c8K2BtCd6c4D8HVmy5fLDSjsH6A=',
         notary: notary
       }),
-      {
-        type: 'ed25519-sha512',
-        signer: notary,
-        public_key: 5678,
-        message_hash: '/3ozzQOVsHdWdsepnEI8uoAk8LEov7BFzV1+1HfMaQuabSPaPhXbg28z4TstwK2TU2f2iXGm/9kEEcKc2fY2xA=='
-      })
+      'cc:1:25:xQ9r0aMDlFYcaicrjVyIEqO8f7ZtWx7vsf9iGhuyMEw:121')
   })
 })

--- a/test/notaryUtils.test.js
+++ b/test/notaryUtils.test.js
@@ -43,14 +43,14 @@ describe('notaryUtils.setupCase', function () {
       ]
     }).reply(204)
 
-    const caseID = yield notaryUtils.setupCase({
+    const caseId = yield notaryUtils.setupCase({
       notary,
       transfers: this.transfers,
       receiptCondition: [1],
       expiresAt: '2016-02-02T08:00:02.000Z'
     })
-    const pathParts = caseID.split('/')
-    assert.equal(caseID, notary + '/cases/' + pathParts[pathParts.length - 1])
+    const pathParts = caseId.split('/')
+    assert.equal(caseId, notary + '/cases/' + pathParts[pathParts.length - 1])
     caseNock.done()
   })
 
@@ -68,26 +68,26 @@ describe('notaryUtils.setupCase', function () {
       ]
     }).reply(204)
 
-    const caseID = notaryUtils.createCaseID()
-    const usedCaseID = yield notaryUtils.setupCase({
+    const caseId = notaryUtils.createCaseId()
+    const usedcaseId = yield notaryUtils.setupCase({
       notary,
-      caseID,
+      caseId,
       transfers: this.transfers,
       receiptCondition: [1],
       expiresAt: '2016-02-02T08:00:02.000Z'
     })
-    const pathParts = caseID.split('/')
-    assert.equal('http://notary.example/cases/' + caseID, notary + '/cases/' + pathParts[pathParts.length - 1])
-    assert.equal('http://notary.example/cases/' + caseID, usedCaseID)
+    const pathParts = caseId.split('/')
+    assert.equal('http://notary.example/cases/' + caseId, notary + '/cases/' + pathParts[pathParts.length - 1])
+    assert.equal('http://notary.example/cases/' + caseId, usedcaseId)
     caseNock.done()
   })
 
-  it('checks than a invalid caseID is rejected', function * () {
-    const caseID = '3c34c136-43cc-4566-ae3a-442e3553bd04-85cd4eec-b2f2-4f23-9b69-cc2829bf2aa9'
+  it('checks than a invalid caseId is rejected', function * () {
+    const caseId = '3c34c136-43cc-4566-ae3a-442e3553bd04-85cd4eec-b2f2-4f23-9b69-cc2829bf2aa9'
     try {
       yield notaryUtils.setupCase({
         notary,
-        caseID,
+        caseId,
         transfers: this.transfers,
         receiptCondition: [1],
         expiresAt: '2016-02-02T08:00:02.000Z'
@@ -96,42 +96,5 @@ describe('notaryUtils.setupCase', function () {
       return
     }
     assert(false)
-  })
-})
-
-describe('notaryUtils.postFulfillmentToNotary', function () {
-  const transfer = {id: 'http://ledger.example/transfers/1'}
-  const caseID = notary + '/cases/123'
-
-  it('throws on /fulfillment 400', function * () {
-    const stateNock = nock(transfer.id).get('/state').reply(200, {
-      type: 'ed25519-sha512',
-      message: { state: 'prepared' }
-    })
-    const fulfillNock = nock(caseID).put('/fulfillment').reply(400)
-    try {
-      yield notaryUtils.postFulfillmentToNotary(transfer, caseID)
-    } catch (err) {
-      assert.equal(err.status, 400)
-      stateNock.done()
-      fulfillNock.done()
-      return
-    }
-    assert(false)
-  })
-
-  it('posts the type and signature', function * () {
-    const stateNock = nock(transfer.id).get('/state').reply(200, {
-      type: 'ed25519-sha512',
-      signature: 'abcdefg',
-      message: { state: 'prepared' }
-    })
-    const fulfillNock = nock(caseID).put('/fulfillment', {
-      type: 'ed25519-sha512',
-      signature: 'abcdefg'
-    }).reply(204)
-    yield notaryUtils.postFulfillmentToNotary(transfer, caseID)
-    stateNock.done()
-    fulfillNock.done()
   })
 })

--- a/test/transferUtils.test.js
+++ b/test/transferUtils.test.js
@@ -33,25 +33,26 @@ describe('transferUtils.setupTransferChain', function () {
 
 describe('transferUtils.setupConditions', function () {
   it('authorizes the first debit', function () {
+    const executionCondition = '4QRmhUtrxlwQYaO+c8K2BtCd6c4D8HVmy5fLDSjsH6A='
     const transfers = transferUtils.setupConditions(this.setupTransfers, {
       isAtomic: false,
-      executionCondition: [0]
+      executionCondition: executionCondition
     })
     assert.strictEqual(transfers[0].debits[0].authorized, true)
-    assert.deepEqual(transfers[0].execution_condition, [0])
-    assert.deepEqual(transfers[transfers.length - 1].execution_condition, undefined)
+    assert.deepEqual(transfers[0].execution_condition, executionCondition)
+    assert.deepEqual(transfers[transfers.length - 1].execution_condition, executionCondition)
   })
 })
 
 describe('transferUtils.setupTransferConditionsAtomic', function () {
   it('adds conditions and cases', function () {
-    const executionCondition = [1]
-    const cancellationCondition = [2]
+    const executionCondition = 'cc:2:2f:iJDUYZFO49HAOnYWVPNkF6QNrzvF7rWbVoOZjiIOqzc:142'
+    const cancellationCondition = 'cc:1:25:xQ9r0aMDlFYcaicrjVyIEqO8f7ZtWx7vsf9iGhuyMEw:121'
     assert.deepEqual(
       transferUtils.setupTransferConditionsAtomic({
         id: transfer.id,
         expiry_duration: 1
-      }, {caseID: 123, executionCondition, cancellationCondition}),
+      }, {caseId: 123, executionCondition, cancellationCondition}),
       {
         id: transfer.id,
         execution_condition: executionCondition,
@@ -62,30 +63,17 @@ describe('transferUtils.setupTransferConditionsAtomic', function () {
 })
 
 describe('transferUtils.setupTransferConditionsUniversal', function () {
-  it('adds the execution_condition when isFinalTransfer=false', function () {
-    const executionCondition = [1]
+  it('adds the execution_condition', function () {
+    const executionCondition = '4QRmhUtrxlwQYaO+c8K2BtCd6c4D8HVmy5fLDSjsH6A='
     assert.deepEqual(
       transferUtils.setupTransferConditionsUniversal({
         id: transfer.id,
         expiry_duration: 1
-      }, {isFinalTransfer: false, now, executionCondition}),
+      }, {now, executionCondition}),
       {
         id: transfer.id,
         expires_at: '2016-02-02T08:00:01.000Z',
         execution_condition: executionCondition
-      })
-  })
-
-  it('doesn\'t add the execution_condition when isFinalTransfer=true', function () {
-    const executionCondition = {}
-    assert.deepEqual(
-      transferUtils.setupTransferConditionsUniversal({
-        id: transfer.id,
-        expiry_duration: 1
-      }, {isFinalTransfer: true, now, executionCondition}),
-      {
-        id: transfer.id,
-        expires_at: '2016-02-02T08:00:01.000Z'
       })
   })
 })
@@ -146,26 +134,5 @@ describe('transferUtils.transferExpiresAt', function () {
     assert.equal(
       transferUtils.transferExpiresAt(1454400000000, {expiry_duration: 2}),
       '2016-02-02T08:00:02.000Z')
-  })
-})
-
-describe('transferUtils.getTransferState', function () {
-  it('returns the response body on 200', function * () {
-    const transferNock = nock(transfer.id).get('/state').reply(200, {foo: 'bar'})
-    const body = yield transferUtils.getTransferState(transfer)
-    assert.deepEqual(body, {foo: 'bar'})
-    transferNock.done()
-  })
-
-  it('should throw an error on 400', function * () {
-    const transferNock = nock(transfer.id).get('/state').reply(400)
-    try {
-      yield transferUtils.getTransferState(transfer)
-    } catch (err) {
-      assert.equal(err.status, 400)
-      transferNock.done()
-      return
-    }
-    assert(false)
   })
 })


### PR DESCRIPTION
This migrates Five Bells Sender to the new crypto-conditions format. See https://github.com/interledger/five-bells-condition

It also removes the last-transfer-as-fulfillment feature. This feature was kind of a hack and required a lot of extra rules in the sender and connector. Both the proprietary (Ripple Connect) as well as the open-source (five-bells-wallet) flows do not require it anymore. So we can get rid of a bunch of code.

Requires interledger/five-bells-ledger#233, interledger/five-bells-connector#146 and interledger/five-bells-notary#57.