### PR TITLE
BREAKING: ILP Packet

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bignumber.js": "^2.3.0",
     "co": "^4.6.0",
     "five-bells-condition": "^3.0.1",
-    "five-bells-shared": "~14.0.0",
+    "five-bells-shared": "~16.1.0",
     "node-uuid": "^1.4.7",
     "superagent": "^1.5.0"
   },

--- a/src/quoteUtils.js
+++ b/src/quoteUtils.js
@@ -82,11 +82,10 @@ function quoteToTransfer (quote, sourceAccount, destinationAccount) {
       account: quote.source_connector_account,
       amount: quote.source_amount,
       memo: {
-        destination_transfer: {
+        ilp_header: {
           ledger: quote.destination_ledger,
-          debits: [{ account: null, amount: quote.destination_amount }],
-          credits: [{ account: destinationAccount, amount: quote.destination_amount }],
-          expiry_duration: quote.destination_expiry_duration
+          account: destinationAccount,
+          amount: quote.destination_amount
         }
       }
     }],

--- a/test/fixtures/quote.json
+++ b/test/fixtures/quote.json
@@ -7,17 +7,10 @@
     "amount": "10",
     "account": "http://usd-ledger.example/accounts/mark",
     "memo": {
-      "destination_transfer": {
+      "ilp_header": {
         "ledger": "http://eur-ledger.example",
-        "debits": [{
-          "amount": "4.87",
-          "account": "http://eur-ledger.example/accounts/mark"
-        }],
-        "credits": [{
-          "amount": "4.87",
-          "account": "http://eur-ledger.example/accounts/bob"
-        }],
-        "expiry_duration": 1000
+        "amount": "4.87",
+        "account": "http://eur-ledger.example/accounts/bob"
       }
     }
   }],

--- a/test/quoteUtils.test.js
+++ b/test/quoteUtils.test.js
@@ -128,11 +128,10 @@ describe('quoteUtils.quoteToTransfer', function () {
           account: 'http://ledgerA.example/accounts/mark',
           amount: '100',
           memo: {
-            destination_transfer: {
+            ilp_header: {
               ledger: 'http://ledgerC.example',
-              debits: [{ account: null, amount: '50' }],
-              credits: [{ account: bob, amount: '50' }],
-              expiry_duration: 5
+              account: bob,
+              amount: '50'
             }
           }
         }],

--- a/test/transferUtils.test.js
+++ b/test/transferUtils.test.js
@@ -12,30 +12,23 @@ const transferUtils = require('../src/transferUtils')
 const transfer = { id: 'http://ledger.example/transfers/1234' }
 const now = 1454400000000
 
-const alice = 'http://usd-ledger.example/accounts/alice'
-const bob = 'http://eur-ledger.example/accounts/bob'
-
 beforeEach(function () {
   this.quote = clone(require('./fixtures/quote.json'))
-  this.setupTransfer = transferUtils.setupTransfers(this.quote, alice, bob)
+  this.setupTransfer = transferUtils.setupTransferId(this.quote)
   this.transfers = clone(require('./fixtures/transfers.json'))
 })
 
-describe('transferUtils.setupTransfers', function () {
-  it('sets up a valid payment', function () {
+describe('transferUtils.setupTransferId', function () {
+  it('sets up a valid transfer id', function () {
     assert(isTransferID('usd', this.setupTransfer.id))
-    assert(isTransferID('eur', this.setupTransfer.credits[0].memo.destination_transfer.id))
   })
 
-  it('should use provided transfer IDs', function () {
+  it('should use provided transfer ID', function () {
     const sourceTransferId = 'http://eur-ledger.example/transfers/d3170b2b-7b98-4528-8ace-d810460dbe15'
-    const destinationTransferId = 'http://eur-ledger.example/transfers/35bc13b3-b929-446d-9ed7-e78d75abef07'
     const quote = clone(this.quote)
     quote.id = sourceTransferId
-    quote.credits[0].memo.destination_transfer.id = destinationTransferId
-    const transfer = transferUtils.setupTransfers(quote, alice, bob)
+    const transfer = transferUtils.setupTransferId(quote)
     assert.equal(transfer.id, sourceTransferId)
-    assert.equal(transfer.credits[0].memo.destination_transfer.id, destinationTransferId)
   })
 })
 
@@ -48,7 +41,6 @@ describe('transferUtils.setupConditions', function () {
     })
     assert.strictEqual(transfer.debits[0].authorized, true)
     assert.deepEqual(transfer.execution_condition, executionCondition)
-    assert.deepEqual(transfer.credits[0].memo.destination_transfer.execution_condition, executionCondition)
   })
 })
 


### PR DESCRIPTION
In order to support different types of ledgers, the information that travels with the transfer should be ledger-agnostic. We've identified the minimum set of fields necessary to get the payment to its destination: `destinationAccount` and `destinationAmount`, called the ILP packet or ILP header.

This PR changes the format of the transfer memos to include the ILP header instead of the destination_transfer object as before.

Related PRs:

interledger/five-bells-connector#160
interledger/five-bells-notary#65
interledger/five-bells-shared#142